### PR TITLE
torchmetrics 0.11.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@ upload_channels:
   - sk_test
 channels:
   - sk_test
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,5 +61,3 @@ extra:
   recipe-maintainers:
     - Borda
     - williamFalcon
-  skip-lints:
-    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   # pytorch hasn't python 3.11 support on ppc64le
-  skip: True  # [py<37 or (linux and ppc64le and py>311)]
+  skip: True  # [py<37 or ((linux and ppc64le) and py>311))]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   # pytorch hasn't python 3.11 support on ppc64le
-  skip: True  # [py<37 or ((linux and ppc64le) and py>311))]
+  skip: True  # [py<37 or ((linux and ppc64le) and py>=311))]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   # Update an url to https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   # when the package will be available on PyPI.
   url: https://github.com/Lightning-AI/metrics/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1c48fea9bc466cd618af1ce09134aa86829a4c8883305982710250df0058e711
+  sha256: 78d7f74b9ca2435104e7a3b4ee25594c4fda59ca241056edfa1d104ea7fac1ae
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchmetrics" %}
-{% set version = "0.11.2" %}
+{% set version = "0.11.4" %}
 
 package:
   name: {{ name|lower }}
@@ -9,11 +9,12 @@ source:
   # Update an url to https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   # when the package will be available on PyPI.
   url: https://github.com/Lightning-AI/metrics/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 78d7f74b9ca2435104e7a3b4ee25594c4fda59ca241056edfa1d104ea7fac1ae
+  sha256: fb58c830b67902acfd0fc5ddee268a64bdc476c41fb571347c6134c261f1723d
 
 build:
   number: 1
-  skip: True  # [py<37]
+  # pytorch hasn't python 3.11 support on ppc64le
+  skip: True  # [py<37 or (linux and ppc64le and py>311)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -27,7 +28,7 @@ requirements:
     - python
     - numpy >=1.17.2
     - packaging  # hotfix for utils, can be dropped with lit-utils >=0.5
-    - pytorch >=1.8.1
+    - pytorch >=1.8.1,<2.0.0
     - typing-extensions  # [py<39]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python
     - numpy >=1.17.2
     - packaging  # hotfix for utils, can be dropped with lit-utils >=0.5
-    - pytorch >=1.8.1,<2.0.0
+    - pytorch >=1.8.1
     - typing-extensions  # [py<39]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: fb58c830b67902acfd0fc5ddee268a64bdc476c41fb571347c6134c261f1723d
 
 build:
-  number: 1
-  # pytorch hasn't python 3.11 support on ppc64le
-  skip: True  # [py<37 or ((linux and ppc64le) and py>=311)]
+  number: 0
+  # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
+  # pytorch <=1.13.1 hasn't python 3.11 support on win
+  skip: True  # [py<37 or (((linux and ppc64le) or win) and py==311)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   # pytorch hasn't python 3.11 support on ppc64le
-  skip: True  # [py<37 or ((linux and ppc64le) and py>=311))]
+  skip: True  # [py<37 or ((linux and ppc64le) and py>=311)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,9 @@ source:
   sha256: 1c48fea9bc466cd618af1ce09134aa86829a4c8883305982710250df0058e711
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -59,3 +59,5 @@ extra:
   recipe-maintainers:
     - Borda
     - williamFalcon
+  skip-lints:
+    - python_build_tool_in_run


### PR DESCRIPTION
Changelog: https://github.com/Lightning-AI/torchmetrics/blob/v0.11.4/CHANGELOG.md
Requirements:
- https://github.com/Lightning-AI/torchmetrics/blob/v0.11.4/pyproject.toml
- https://github.com/Lightning-AI/torchmetrics/blob/v0.11.4/requirements.txt
- https://github.com/Lightning-AI/torchmetrics/blob/v0.11.4/setup.py

Actions:
1. Skip `(linux and ppc64le) and py>=311` because of `pytorch` isn't available on `ppc64le` for python 3.11
2. Add `--no-build-isolation` flag to `script`
3. Update pinnings for `pytorch` in `run`: `pytorch >=1.8.1,<2.0.0`
4. Skip lint `python_build_tool_in_run`

Notes:
- https://github.com/AnacondaRecipes/pytorch-lightning-feedstock/pull/5 and https://github.com/AnacondaRecipes/gluon-ts-feedstock/pull/2 require this package with python 3.11 support