### PR TITLE
Rebuild torchmetrics 0.11.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
-  skip: True  # [py<37 or ((linux and ppc64le) and py==311)]
+  skip: True  # [py<37 or (py>310 and (linux and ppc64le))]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,9 @@ source:
   sha256: fb58c830b67902acfd0fc5ddee268a64bdc476c41fb571347c6134c261f1723d
 
 build:
-  number: 0
+  number: 1
   # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
-  # pytorch <=1.13.1 hasn't python 3.11 support on win
-  skip: True  # [py<37 or (((linux and ppc64le) or win) and py==311)]
+  skip: True  # [py<37 or ((linux and ppc64le) and py==311)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Rebuild for python 3.11. support on win64 as pytorch 2.0.1 is available:
https://repo.anaconda.com/pkgs/main/win-64
```
pytorch-2.0.1-cpu_py310hb0bdfb8_0.tar.bz2
pytorch-2.0.1-cpu_py311hd080823_0.tar.bz2
pytorch-2.0.1-cpu_py38hb0bdfb8_0.tar.bz2
pytorch-2.0.1-cpu_py39hb0bdfb8_0.tar.bz2
```

Notes:
- pytorch-lightning 2.0.3 requires it https://github.com/AnacondaRecipes/pytorch-lightning-feedstock/pull/4