### PR TITLE
Update to 1.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  # Update an url to https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # when the package will be available on PyPI.
-  url: https://github.com/Lightning-AI/metrics/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 55df8242752fbb6c46d5c54447f09c6991e490ed9580a08b24f82382d3c61048
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 44b01d3c7ca6aa925ac888adff0b0b7c2b2194ff662cf58eb6e05e0e8eb51b00
 
 build:
   number: 0
@@ -25,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.20.0
+    - numpy >1.20.0
     - pytorch >=1.8.1
     - lightning-utilities >=0.8.0
     - typing-extensions  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchmetrics" %}
-{% set version = "0.11.4" %}
+{% set version = "1.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -9,31 +9,31 @@ source:
   # Update an url to https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   # when the package will be available on PyPI.
   url: https://github.com/Lightning-AI/metrics/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: fb58c830b67902acfd0fc5ddee268a64bdc476c41fb571347c6134c261f1723d
+  sha256: 55df8242752fbb6c46d5c54447f09c6991e490ed9580a08b24f82382d3c61048
 
 build:
-  number: 1
+  number: 0
   # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
-  skip: True  # [py<37 or (py>310 and (linux and ppc64le))]
+  skip: True  # [py<38 or (py>310 and (linux and ppc64le))]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
-    - numpy
     - pip
     - setuptools
     - wheel
   run:
     - python
-    - numpy >=1.17.2
-    - packaging  # hotfix for utils, can be dropped with lit-utils >=0.5
+    - numpy >=1.20.0
     - pytorch >=1.8.1
+    - lightning-utilities >=0.8.0
     - typing-extensions  # [py<39]
 
 test:
   imports:
     - torchmetrics
+    - torchmetrics.utilities.imports
   requires:
     - pip
   commands:


### PR DESCRIPTION
Upstream: https://github.com/Lightning-AI/torchmetrics/tree/v1.1.2

Channel: defaults

Note that we are not updating to the latest yet because autogluon will require <1.2.