### PR TITLE
torchmetrics 1.1.2 [py312 fix]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 44b01d3c7ca6aa925ac888adff0b0b7c2b2194ff662cf58eb6e05e0e8eb51b00
 
 build:
-  number: 0
+  number: 1
   # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
   skip: True  # [py<38 or (py>310 and (linux and ppc64le))]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 1
   # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
-  skip: True  # [py<38 or (py>310 and (linux and ppc64le))]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
torchmetrics 1.1.2 [py312]

**Destination channel:** defaults

### Links

- [PKG-5043]
- dev_url (pypi): https://github.com/Lightning-AI/torchmetrics/tree/v1.1.2
- conda-forge: https://github.com/conda-forge/torchmetrics-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/torchmetrics/1.1.2
- pypi inspector: https://inspector.pypi.io/project/torchmetrics/1.1.2

### Explanation of changes:

- rebuild, bump build number

### Note for Reviewers

- There is no skip for `linux-64`, but the artifacts are not there. This re-build aims to just fix that.

- All the `py312` are there, except for `linux-64`, but there is no skip `py312` for `linux-64`:

```
for p in linux-{64,s390x,aarch64} win-64 osx-{64,arm64}; do echo -e "*** $p"; conda search -q --platform=$p "torchmetrics==1.1.2" -c main --override-channels; echo ""; done
*** linux-64
Loading channels: ...working... done
# Name                       Version           Build  Channel
torchmetrics                   1.1.2 py310h06a4308_0  main
torchmetrics                   1.1.2 py311h06a4308_0  main
torchmetrics                   1.1.2  py38h06a4308_0  main
torchmetrics                   1.1.2  py39h06a4308_0  main

*** linux-s390x
Loading channels: ...working... done
# Name                       Version           Build  Channel
torchmetrics                   1.1.2 py310ha847dfd_0  main
torchmetrics                   1.1.2 py311ha847dfd_0  main
torchmetrics                   1.1.2 py312ha847dfd_0  main
torchmetrics                   1.1.2  py38ha847dfd_0  main
torchmetrics                   1.1.2  py39ha847dfd_0  main

*** linux-aarch64
Loading channels: ...working... done
# Name                       Version           Build  Channel
torchmetrics                   1.1.2 py310hd43f75c_0  main
torchmetrics                   1.1.2 py311hd43f75c_0  main
torchmetrics                   1.1.2 py312hd43f75c_0  main
torchmetrics                   1.1.2  py38hd43f75c_0  main
torchmetrics                   1.1.2  py39hd43f75c_0  main

*** win-64
Loading channels: ...working... done
# Name                       Version           Build  Channel
torchmetrics                   1.1.2 py310haa95532_0  main
torchmetrics                   1.1.2 py311haa95532_0  main
torchmetrics                   1.1.2 py312haa95532_0  main
torchmetrics                   1.1.2  py38haa95532_0  main
torchmetrics                   1.1.2  py39haa95532_0  main

*** osx-64
Loading channels: ...working... done
# Name                       Version           Build  Channel
torchmetrics                   1.1.2 py310hecd8cb5_0  main
torchmetrics                   1.1.2 py311hecd8cb5_0  main
torchmetrics                   1.1.2 py312hecd8cb5_0  main
torchmetrics                   1.1.2  py38hecd8cb5_0  main
torchmetrics                   1.1.2  py39hecd8cb5_0  main

*** osx-arm64
Loading channels: ...working... done
# Name                       Version           Build  Channel
torchmetrics                   1.1.2 py310hca03da5_0  main
torchmetrics                   1.1.2 py311hca03da5_0  main
torchmetrics                   1.1.2 py312hca03da5_0  main
torchmetrics                   1.1.2  py38hca03da5_0  main
torchmetrics                   1.1.2  py39hca03da5_0  main

```

- See previous PR: https://github.com/AnacondaRecipes/torchmetrics-feedstock/pull/8/files

[PKG-5043]: https://anaconda.atlassian.net/browse/PKG-5043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ