### PR TITLE
torchmetrics 1.4.0.post0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchmetrics" %}
-{% set version = "1.1.2" %}
+{% set version = "1.4.0.post0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 44b01d3c7ca6aa925ac888adff0b0b7c2b2194ff662cf58eb6e05e0e8eb51b00
+  sha256: ab9bcfe80e65dbabbddb6cecd9be21f1f1d5207bb74051ef95260740f2762358
 
 build:
-  number: 1
-  # pytorch hasn't python 3.11 support on ppc64le: ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
+  number: 0
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -24,8 +23,8 @@ requirements:
   run:
     - python
     - numpy >1.20.0
-    - pytorch >=1.8.1
-    - lightning-utilities >=0.8.0
+    - pytorch >=1.10.0,<2.4.0
+    - lightning-utilities >=0.8.0,<0.12.0
     - typing-extensions  # [py<39]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,29 +29,29 @@ requirements:
   run_constrained:
     # Optional depedencies from torchmetrics/requirements
     # audio
-    - pystoi >=0.3.0,<0.5.0
-    - torchaudio >=0.10.0,<2.4.0
+    - pystoi >=0.3.0
+    - torchaudio >=0.10.0
     # detection
-    - torchvision >=0.8,<0.19.0
-    - pycocotools >2.0.0,<=2.0.7
+    - torchvision >=0.8
+    - pycocotools >2.0.0
     # image
-    - scipy >1.0.0,<1.11.0
+    - scipy >1.0.0
     #- torchvision >=0.8,<0.19.0
     - torch-fidelity <=0.4.0
     # multimodal
-    - transformers >=4.10.0,<4.41.0
+    - transformers >=4.10.0
     - piq <=0.8.0
     # text
-    - nltk >=3.6,<=3.8.1
-    - tqdm >=4.41.0,<4.67.0
-    - regex >=2021.9.24,<=2024.5.10
+    - nltk >=3.6
+    - tqdm >=4.41.0
+    - regex >=2021.9.24
     #- transformers >4.4.0,<4.41.0
-    - mecab-python3 >=1.0.6,<1.1.0
-    - ipadic >=1.0.0, <1.1.0
-    - sentencepiece >=0.2.0,<0.3.0
+    - mecab-python3 >=1.0.6
+    - ipadic >=1.0.0
+    - sentencepiece >=0.2.0
     # visual
-    - matplotlib-base >=3.3.0,<3.9.0
-    - SciencePlots >=2.0.0,<2.2.0
+    - matplotlib-base >=3.3.0
+    - SciencePlots >=2.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
   run:
     - python
     - numpy >1.20.0
-    - pytorch >=1.10.0,<2.4.0
-    - lightning-utilities >=0.8.0,<0.12.0
+    - pytorch >=1.10.0
+    - lightning-utilities >=0.8.0
     - typing-extensions  # [py<39]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,32 @@ requirements:
     - pytorch >=1.10.0
     - lightning-utilities >=0.8.0
     - typing-extensions  # [py<39]
+  run_constrained:
+    # Optional depedencies from torchmetrics/requirements
+    # audio
+    - pystoi >=0.3.0,<0.5.0
+    - torchaudio >=0.10.0,<2.4.0
+    # detection
+    - torchvision >=0.8,<0.19.0
+    - pycocotools >2.0.0,<=2.0.7
+    # image
+    - scipy >1.0.0,<1.11.0
+    #- torchvision >=0.8,<0.19.0
+    - torch-fidelity <=0.4.0
+    # multimodal
+    - transformers >=4.10.0,<4.41.0
+    - piq <=0.8.0
+    # text
+    - nltk >=3.6,<=3.8.1
+    - tqdm >=4.41.0,<4.67.0
+    - regex >=2021.9.24,<=2024.5.10
+    #- transformers >4.4.0,<4.41.0
+    - mecab-python3 >=1.0.6,<1.1.0
+    - ipadic >=1.0.0, <1.1.0
+    - sentencepiece >=0.2.0,<0.3.0
+    # visual
+    - matplotlib-base >=3.3.0,<3.9.0
+    - SciencePlots >=2.0.0,<2.2.0
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-2732](https://anaconda.atlassian.net/browse/PKG-2732) 
- [Upstream repository](https://github.com/Lightning-AI/torchmetrics/tree/v1.4.0.post0)
- Requirements:
  - https://github.com/Lightning-AI/torchmetrics/blob/v1.4.0.post0/pyproject.toml
  - https://github.com/Lightning-AI/torchmetrics/blob/v1.4.0.post0/setup.py
  - https://github.com/Lightning-AI/torchmetrics/blob/v1.4.0.post0/requirements/base.txt

### Explanation of changes:

- Reset the build number
- Update runtime pinnings

### Notes:

- Updating because of the `pytorch 2.3.0` release

[PKG-2732]: https://anaconda.atlassian.net/browse/PKG-2732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ